### PR TITLE
Fixed tests broken by renaming `sessionId` to `kindeSessionId`

### DIFF
--- a/test/sdk/KindeClient.spec.js
+++ b/test/sdk/KindeClient.spec.js
@@ -76,7 +76,7 @@ import sinon from 'sinon';
       it('should call login successfully', async () => {
         req.query = { state: 'random_state', org_code: 'org-code' };
         KindeManagementApi.SessionStore.setData('session-id', {});
-        req.headers.cookie = 'sessionId=session-id';
+        req.headers.cookie = 'kindeSessionId=session-id';
         sandbox.stub(KindeManagementApi.AuthorizationCode.prototype, 'generateAuthorizationURL').returns('https://example.com/oauth2/auth?response_type=code&client_id=client_id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=openid%20profile%20email%20offline&state=random_state&org_code=org_code&start_page=login');
         await instance.login()(req, res, next);
         expect(res.cookie.calledOnce).to.be(true);
@@ -117,7 +117,7 @@ import sinon from 'sinon';
       it('should call register successfully', async () => {
         req.query = { state: 'random_state', org_code: 'org-code' };
         KindeManagementApi.SessionStore.setData('session-id', {});
-        req.headers.cookie = 'sessionId=session-id';
+        req.headers.cookie = 'kindeSessionId=session-id';
         sandbox.stub(KindeManagementApi.AuthorizationCode.prototype, 'generateAuthorizationURL').returns('https://example.com/oauth2/auth?response_type=code&client_id=client_id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=openid%20profile%20email%20offline&state=random_state&org_code=org_code&start_page=registration');
         await instance.register()(req, res, next);
         expect(res.cookie.calledOnce).to.be(true);
@@ -181,7 +181,7 @@ import sinon from 'sinon';
         KindeManagementApi.SessionStore.setData('session-id', {
           kindeOauthState: 'random_state'
         });
-        req.headers.cookie = 'sessionId=session-id';
+        req.headers.cookie = 'kindeSessionId=session-id';
         const getTokenStub = sinon.stub(KindeManagementApi.AuthorizationCode.prototype, 'getToken').resolves({
           access_token: validToken,
           id_token: validToken,
@@ -228,7 +228,7 @@ import sinon from 'sinon';
       it('should call createOrg successfully', async () => {
         req.query = { state: 'random_state', org_code: 'org-code' };
         KindeManagementApi.SessionStore.setData('session-id', {});
-        req.headers.cookie = 'sessionId=session-id';
+        req.headers.cookie = 'kindeSessionId=session-id';
         sandbox.stub(KindeManagementApi.AuthorizationCode.prototype, 'generateAuthorizationURL').returns('https://example.com/oauth2/auth?response_type=code&client_id=client_id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=openid%20profile%20email%20offline&state=random_state&start_page=registration&is_create_org=true&org_name=org_name');
         await instance.createOrg()(req, res, next);
         expect(res.cookie.calledOnce).to.be(true);
@@ -248,7 +248,7 @@ import sinon from 'sinon';
       it('should call logout successfully', () => {
         const req = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         const res = {
@@ -282,7 +282,7 @@ import sinon from 'sinon';
       it('should call getToken successfully', async () => {
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         KindeManagementApi.SessionStore.setData('session-id', {
@@ -403,7 +403,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         sandbox.stub(instance, 'isTokenExpired').returns(false);
@@ -415,7 +415,7 @@ import sinon from 'sinon';
         KindeManagementApi.SessionStore.setData('session-id', {});
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         const isAuthenticated = await instance.isAuthenticated(request);
@@ -441,7 +441,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         sandbox.stub(instance, 'isAuthenticated').returns(true);
@@ -458,7 +458,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         const defaultValue = true;
@@ -476,7 +476,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         sandbox.stub(instance, 'isAuthenticated').returns(true);
@@ -493,7 +493,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         const defaultValue = 123;
@@ -522,7 +522,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         const defaultValue = true;
@@ -537,7 +537,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         const defaultValue = true;
@@ -552,7 +552,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         sandbox.stub(instance, 'isAuthenticated').returns(true);
@@ -569,7 +569,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         sandbox.stub(instance, 'isAuthenticated').returns(true);
@@ -597,7 +597,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         sandbox.stub(instance, 'isAuthenticated').returns(true);
@@ -611,7 +611,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         const defaultValue = 'default-value';
@@ -626,7 +626,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         sandbox.stub(instance, 'isAuthenticated').returns(true);
@@ -643,7 +643,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         sandbox.stub(instance, 'isAuthenticated').returns(true);
@@ -671,7 +671,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         sandbox.stub(instance, 'isAuthenticated').returns(true);
@@ -685,7 +685,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         const defaultValue = 42;
@@ -700,7 +700,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         sandbox.stub(instance, 'isAuthenticated').returns(true);
@@ -717,7 +717,7 @@ import sinon from 'sinon';
         });
         const request = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         sandbox.stub(instance, 'isAuthenticated').returns(true);
@@ -755,7 +755,7 @@ import sinon from 'sinon';
         });
         const req = {
           headers: {
-            cookie: 'sessionId=session-id',
+            cookie: 'kindeSessionId=session-id',
           },
         };
         const isAuthenticatedStub = sinon.stub(instance, 'isAuthenticated').returns(true);  
@@ -796,7 +796,7 @@ import sinon from 'sinon';
         KindeManagementApi.SessionStore.setData('session-id', {
           kindeIdToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
         });
-        req.headers.cookie = 'sessionId=session-id';
+        req.headers.cookie = 'kindeSessionId=session-id';
         sandbox.stub(instance, 'isAuthenticated').returns(true);
         const claims = instance.getClaims(req, 'id_token');
         expect(claims).to.be.an('object');


### PR DESCRIPTION
# Explain your changes
Presently the tests in  `@kinde-oss/kinde-nodejs-sdk` are broken, after :point_right: [this](https://github.com/kinde-oss/kinde-nodejs-sdk/commit/c1f136605053905c8a690b07574e008880756460) commit, this pull request fixes them.

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
