### PR TITLE
Fix call to `login` method in `register` function tests

### DIFF
--- a/test/sdk/KindeClient.spec.js
+++ b/test/sdk/KindeClient.spec.js
@@ -141,7 +141,7 @@ import sinon from 'sinon';
         req.query = { post_login_redirect_url: '/post-login-url' };
         req.headers.cookie = `kindeSessionId=${sessionId}`;
         KindeManagementApi.SessionStore.setData(sessionId, {});
-        await instance.login()(req, res, next);
+        await instance.register()(req, res, next);
         const cachedPostLoginParam = KindeManagementApi.SessionStore.getDataByKey(sessionId, 'kindePostLoginRedirectUrl');
         expect(cachedPostLoginParam).to.be(req.query.post_login_redirect_url);
       });


### PR DESCRIPTION
# Explain your changes

This pull request rectifies a small issue that was missed in [this](https://github.com/kinde-oss/kinde-nodejs-generator/pull/13) PR. The test case "_stores provided "post_login_redirect_url query param to memory_" for the `register` function in the calls the `login` function when it should call the `register` function. The corresponding PR for the generator can be found [here](https://github.com/kinde-oss/kinde-nodejs-generator/pull/15).

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
