### PR TITLE
Fix to set kindeSessionId cookie to 29 days

### DIFF
--- a/src/sdk/constant/CookieOptions.js
+++ b/src/sdk/constant/CookieOptions.js
@@ -1,5 +1,5 @@
 const CookieOptions = {
-  maxAge: 86399 * 1000,
+  maxAge: 29 * 86399 * 1000,
   secure: true,
   httpOnly: true,
 };


### PR DESCRIPTION
# Fixes expiration of kindeSessionId cookie

This is limited to one day in both Node.JS and Node.JS express. The **Next** SDK sets the cookie expiration at 29 days so I adjusted the hard coded value accordingly.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
