### PR TITLE
chore: update CODEOWNERS for dependency files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
 * @kinde-oss/giants-kinde
+package-lock.json @kinde-oss/sdk-engineers
+**/package-lock.json @kinde-oss/sdk-engineers
+package.json @kinde-oss/sdk-engineers
+**/package.json @kinde-oss/sdk-engineers


### PR DESCRIPTION
Automated update to CODEOWNERS so that @kinde-oss/sdk-engineers own dependency definition files and can approve dependency PRs.